### PR TITLE
Generated temp directory should have real (dereferenced) path 

### DIFF
--- a/testkraut/tests/utils.py
+++ b/testkraut/tests/utils.py
@@ -16,7 +16,12 @@ def with_tempdir(*targs, **tkwargs):
     def decorate(func):
         def newfunc(*arg, **kwargs):
             import tempfile
-            wdir = tempfile.mkdtemp(*targs, **tkwargs)
+            from os.path import realpath
+            # realpath so the logic about relative paths do not break
+            # when TMPDIR is pointing to a directory which is a symlink.
+            # This is just a workaround for
+            # https://github.com/neurodebian/testkraut/issues/24
+            wdir = realpath(tempfile.mkdtemp(*targs, **tkwargs))
             try:
                 func(*((wdir,) + arg), **kwargs)
             finally:


### PR DESCRIPTION
This is a workaround for #24 which needs a "real" fix IMHO
